### PR TITLE
Remove expired cookies in session

### DIFF
--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -289,7 +289,7 @@ case class Requester(verb: String,
               .iterator
               .flatten
               .flatMap(HttpCookie.parse(_).asScala)
-              .sortedBy(_.hasExpired)
+              .sortedBy(_.hasExpired)(Ordering[Boolean].reverse)
               .foreach(
                 c => if c.hasExpired sess.cookies.remove(c.getName) else sess.cookies(c.getName) = c
               )

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -289,7 +289,10 @@ case class Requester(verb: String,
               .iterator
               .flatten
               .flatMap(HttpCookie.parse(_).asScala)
-              .foreach(c => sess.cookies(c.getName) = c)
+              .sortedBy(_.hasExpired)
+              .foreach(
+                c => if c.hasExpired sess.cookies.remove(c.getName) else sess.cookies(c.getName) = c
+              )
           }
         }
 


### PR DESCRIPTION
Servers usually expire cookies if they want them deleted. Therefore expired cookies should be removed. Since some serves might expire and set the same cookie in a single response expired cookies must be handled before unexpired cookies.