### PR TITLE
Add a common base class for requests exceptions

### DIFF
--- a/requests/src/requests/Exceptions.scala
+++ b/requests/src/requests/Exceptions.scala
@@ -1,15 +1,18 @@
 package requests
 
+// base class for all custom exceptions thrown by requests.
+class RequestsException(val message: String, val cause: Option[Throwable] = None) extends Exception(message, cause.getOrElse(null))
+
 class TimeoutException(val url: String, val readTimeout: Int, val connectTimeout: Int)
-extends Exception(s"Request to $url timed out. (readTimeout: $readTimeout, connectTimout: $connectTimeout)")
+extends RequestsException(s"Request to $url timed out. (readTimeout: $readTimeout, connectTimout: $connectTimeout)")
 
 class UnknownHostException(val url: String, val host: String)
-extends Exception(s"Unknown host $host in url $url")
+extends RequestsException(s"Unknown host $host in url $url")
 
 class InvalidCertException(val url: String, cause: Throwable)
-extends Exception(s"Unable to validate SSL certificates for $url", cause)
+extends RequestsException(s"Unable to validate SSL certificates for $url", Some(cause))
 
 class RequestFailedException(val response: Response)
-extends Exception(
+extends RequestsException(
   s"Request to ${response.url} failed with status code ${response.statusCode}\n${response.text()}"
 )


### PR DESCRIPTION
Sometimes, one wants to catch and handle all exceptions thrown
by requests regardless if it is an HTTP 500 due to a server problem
or a DNS problem. This patch adds such a base class which makes
error handling easier.

This class is similar in purpose to RequestException in the Python
requests library.