### PR TITLE
Allow dynamic choice of HTTP method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,10 @@ val r = requests.delete("http://httpbin.org/delete")
 val r = requests.head("http://httpbin.org/head")
 
 val r = requests.options("http://httpbin.org/get")
+
+// dynamically choose what HTTP method to use
+val r = requests.send("put")("http://httpbin.org/put", data = Map("key" -> "value"))
+
 ```
 
 ### Passing in Parameters

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -34,6 +34,8 @@ trait BaseSession{
   lazy val options = Requester("OPTIONS", this)
   // unofficial
   lazy val patch = Requester("PATCH", this)
+
+  def send(method: String) = Requester(method, this)
 }
 
 object BaseSession{

--- a/requests/test/src-2/requests/Scala2RequestTests.scala
+++ b/requests/test/src-2/requests/Scala2RequestTests.scala
@@ -1,0 +1,44 @@
+package requests
+
+import utest._
+import ujson._
+
+object Scala2RequestTests extends TestSuite{
+  val tests = Tests{
+
+    test("params"){
+
+      test("post"){
+        for(chunkedUpload <- Seq(true, false)) {
+          val res1 = requests.post(
+            "https://httpbin.org/post",
+            data = Map("hello" -> "world", "foo" -> "baz"),
+            chunkedUpload = chunkedUpload
+          ).text()
+          assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+        }
+      }
+      test("put") {
+        for (chunkedUpload <- Seq(true, false)) {
+          val res1 = requests.put(
+            "https://httpbin.org/put",
+            data = Map("hello" -> "world", "foo" -> "baz"),
+            chunkedUpload = chunkedUpload
+          ).text()
+          assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+        }
+      }
+      test("send"){
+        requests.send("get")("https://httpbin.org/get?hello=world&foo=baz")
+
+        val res1 = requests.send("put")(
+          "https://httpbin.org/put",
+          data = Map("hello" -> "world", "foo" -> "baz"),
+          chunkedUpload = true
+        ).text
+
+        assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+      }
+    }
+  }
+}

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -77,6 +77,17 @@ object RequestTests extends TestSuite{
           assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
         }
       }
+      test("send"){
+        requests.send("get")("https://httpbin.org/get?hello=world&foo=baz")
+
+        val res1 = requests.send("put")(
+          "https://httpbin.org/put",
+          data = Map("hello" -> "world", "foo" -> "baz"),
+          chunkedUpload = true
+        ).text
+
+        assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+      }
     }
     test("multipart"){
       for(chunkedUpload <- Seq(true, false)) {

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -57,37 +57,6 @@ object RequestTests extends TestSuite{
         )
         assert(read(res4).obj("args") == Obj("++-- lol" -> " !@#$%", "hello" -> "world"))
       }
-      test("post"){
-        for(chunkedUpload <- Seq(true, false)) {
-          val res1 = requests.post(
-            "https://httpbin.org/post",
-            data = new RequestBlob.FormEncodedRequestBlob(Map("hello" -> "world", "foo" -> "baz")),
-            chunkedUpload = chunkedUpload
-          ).text()
-          assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
-        }
-      }
-      test("put") {
-        for (chunkedUpload <- Seq(true, false)) {
-          val res1 = requests.put(
-            "https://httpbin.org/put",
-            data = new RequestBlob.FormEncodedRequestBlob(Map("hello" -> "world", "foo" -> "baz")),
-            chunkedUpload = chunkedUpload
-          ).text()
-          assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
-        }
-      }
-      test("send"){
-        requests.send("get")("https://httpbin.org/get?hello=world&foo=baz")
-
-        val res1 = requests.send("put")(
-          "https://httpbin.org/put",
-          data = Map("hello" -> "world", "foo" -> "baz"),
-          chunkedUpload = true
-        ).text
-
-        assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
-      }
     }
     test("multipart"){
       for(chunkedUpload <- Seq(true, false)) {


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/requests-scala/issues/67
Fixes https://github.com/com-lihaoyi/requests-scala/issues/52

This was always possible in a roundabout way via


```scala
requests.Requester("get", requests.Session()).apply("https://www.google.com")
```

But this PR adds a convenient alias and documents it for discoverability

```scala
requests.send("get")("https://www.google.com")
```