### PR TITLE
update to latest mill

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -29,11 +29,10 @@ class RequestsModule(val crossScalaVersion: String) extends CrossScalaModule wit
   def ivyDeps = Agg(
     ivy"com.lihaoyi::geny::0.6.10"
   )
-  object test extends Tests{
+  object test extends Tests with TestModule.Utest {
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.7.10",
       ivy"com.lihaoyi::ujson::1.3.13"
     )
-    def testFrameworks = Seq("utest.runner.Framework")
   }
 }

--- a/mill
+++ b/mill
@@ -3,27 +3,39 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.9.12
+DEFAULT_MILL_VERSION=0.10.4
 
 set -e
 
 if [ -z "$MILL_VERSION" ] ; then
   if [ -f ".mill-version" ] ; then
     MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
-  elif [ -f "mill" ] && [ "$BASH_SOURCE" != "mill" ] ; then
+  elif [ -f "mill" ] && [ "$0" != "mill" ] ; then
     MILL_VERSION=$(grep -F "DEFAULT_MILL_VERSION=" "mill" | head -n 1 | cut -d= -f2)
   else
     MILL_VERSION=$DEFAULT_MILL_VERSION
   fi
 fi
 
-MILL_DOWNLOAD_PATH="$HOME/.mill/download"
-MILL_EXEC_PATH="${MILL_DOWNLOAD_PATH}/$MILL_VERSION"
+if [ "x${XDG_CACHE_HOME}" != "x" ] ; then
+  MILL_DOWNLOAD_PATH="${XDG_CACHE_HOME}/mill/download"
+else
+  MILL_DOWNLOAD_PATH="${HOME}/.cache/mill/download"
+fi
+MILL_EXEC_PATH="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
 
-if [ ! -x "$MILL_EXEC_PATH" ] ; then
-  mkdir -p $MILL_DOWNLOAD_PATH
+version_remainder="$MILL_VERSION"
+MILL_MAJOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_remainder#*.}"
+MILL_MINOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_remainder#*.}"
+
+if [ ! -s "$MILL_EXEC_PATH" ] ; then
+  mkdir -p "$MILL_DOWNLOAD_PATH"
+  if [ "$MILL_MAJOR_VERSION" -gt 0 ] || [ "$MILL_MINOR_VERSION" -ge 5 ] ; then
+    ASSEMBLY="-assembly"
+  fi
   DOWNLOAD_FILE=$MILL_EXEC_PATH-tmp-download
-  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION-assembly"
+  MILL_VERSION_TAG=$(echo $MILL_VERSION | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
+  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION_TAG}/$MILL_VERSION${ASSEMBLY}"
   curl --fail -L -o "$DOWNLOAD_FILE" "$MILL_DOWNLOAD_URL"
   chmod +x "$DOWNLOAD_FILE"
   mv "$DOWNLOAD_FILE" "$MILL_EXEC_PATH"


### PR DESCRIPTION
~~I was just looking through this using metals and when it tried to do the
build export it defaults to the latest, which ends up being the
Milestone release which didn't work for the export. In Metals we check
for a .mill-version script typically to grab that version, which most
mill projects seem to have. This PR just adds the version file in and
also updates the millw script to the latest.~~

Alright, ignore all of the above. This just updates to the latest mill now.