### PR TITLE
Fix incorrect Proxy-Authentication handling

### DIFF
--- a/requests/src/requests/Model.scala
+++ b/requests/src/requests/Model.scala
@@ -237,22 +237,22 @@ case class StreamHeaders(url: String,
   * auth and Proxy auth are supported
   */
 trait RequestAuth{
-  def header: Option[String]
+  def credentials: Option[String]
 }
 
 object RequestAuth{
   object Empty extends RequestAuth{
-    def header = None
+    def credentials = None
   }
   implicit def implicitBasic(x: (String, String)): Basic = new Basic(x._1, x._2)
   class Basic(username: String, password: String) extends RequestAuth{
-    def header = Some("Basic " + java.util.Base64.getEncoder.encodeToString((username + ":" + password).getBytes()))
+    def credentials = Some("Basic " + java.util.Base64.getEncoder.encodeToString((username + ":" + password).getBytes()))
   }
   case class Proxy(username: String, password: String) extends RequestAuth{
-    def header = Some("Proxy-Authorization " + java.util.Base64.getEncoder.encodeToString((username + ":" + password).getBytes()))
+    def credentials = Some("Basic " + java.util.Base64.getEncoder.encodeToString((username + ":" + password).getBytes()))
   }
   case class Bearer(token: String) extends RequestAuth {
-    def header = Some(s"Bearer $token")
+    def credentials = Some(s"Bearer $token")
   }
 }
 

--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -230,7 +230,17 @@ case class Requester(verb: String,
         for((k, v) <- compress.headers) connection.setRequestProperty(k, v)
 
         connection.setReadTimeout(readTimeout)
-        auth.header.foreach(connection.setRequestProperty("Authorization", _))
+
+        auth match {
+          case basic: RequestAuth.Basic =>
+            connection.setRequestProperty("Authorization", basic.credentials.get)
+          case bearer: RequestAuth.Bearer =>
+            connection.setRequestProperty("Authorization", bearer.credentials.get)
+          case proxy: RequestAuth.Proxy =>
+            connection.setRequestProperty("Proxy-Authorization", proxy.credentials.get)
+          case RequestAuth.Empty =>
+        }
+
         connection.setConnectTimeout(connectTimeout)
         connection.setUseCaches(false)
         connection.setDoOutput(true)

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -207,6 +207,39 @@ object RequestTests extends TestSuite{
         }
       }
     }
+    test("auth"){
+      test("basicAuth"){
+        val (username, password) = ("foo", "bar")
+        val rawCreds = s"$username:$password"
+        val encodedCreds = java.util.Base64.getEncoder.encodeToString(rawCreds.getBytes())
+        val auth = new RequestAuth.Basic(username, password)
+
+        val res = requests.get("https://httpbin.org/headers", auth=auth).text()
+        val hs = read(res)("headers").obj
+
+        assert(hs("Authorization").str == s"Basic $encodedCreds")
+      }
+      test("bearerAuth"){
+        val token = "foobar"
+        val auth = new RequestAuth.Bearer(token)
+
+        val res = requests.get("https://httpbin.org/headers", auth=auth).text()
+        val hs = read(res)("headers").obj
+
+        assert(hs("Authorization").str == s"Bearer $token")
+      }
+      test("proxyAuth"){
+        val (username, password) = ("foo", "bar")
+        val rawCreds = s"$username:$password"
+        val encodedCreds = java.util.Base64.getEncoder.encodeToString(rawCreds.getBytes())
+        val auth = new RequestAuth.Proxy(username, password)
+
+        val res = requests.get("https://httpbin.org/headers", auth=auth).text()
+        val hs = read(res)("headers").obj
+
+        assert(hs("Proxy-Authorization").str == s"Basic $encodedCreds")
+      }
+    }
     test("clientCertificate"){
       val base = "./requests/test/resources"
       val url = "https://client.badssl.com"

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -229,15 +229,21 @@ object RequestTests extends TestSuite{
         assert(hs("Authorization").str == s"Bearer $token")
       }
       test("proxyAuth"){
-        val (username, password) = ("foo", "bar")
-        val rawCreds = s"$username:$password"
-        val encodedCreds = java.util.Base64.getEncoder.encodeToString(rawCreds.getBytes())
-        val auth = new RequestAuth.Proxy(username, password)
-
-        val res = requests.get("https://httpbin.org/headers", auth=auth).text()
-        val hs = read(res)("headers").obj
-
-        assert(hs("Proxy-Authorization").str == s"Basic $encodedCreds")
+        // @TODO Need a service that echos the Proxy-Authorization header back.
+        //
+        // From RFC: "Unlike Authorization, the Proxy-Authorization header field
+        // applies only to the next inbound proxy that demanded authentication
+        // using the Proxy-Authenticate field." [0]
+        //
+        // [0] https://tools.ietf.org/html/rfc7235#section-4.4
+        //
+        // val (username, password) = ("foo", "bar")
+        // val rawCreds = s"$username:$password"
+        // val encodedCreds = java.util.Base64.getEncoder.encodeToString(rawCreds.getBytes())
+        // val auth = new RequestAuth.Proxy(username, password)
+        // val res = requests.get("http://localhost:8881", auth=auth).text()
+        // val hs = read(res)("headers").obj
+        // assert(hs("Proxy-Authorization").str == s"Basic $encodedCreds")
       }
     }
     test("clientCertificate"){


### PR DESCRIPTION
I noticed that the `Proxy-Authorization` header was being inserted as a value in the `Authorization: ..` header when using `RequestAuth.Proxy(..)`.

1) Using `requests.RequestAuth.Proxy`:
```scala
@ val reqProxy = requests.RequestAuth.Proxy("username", "password")
reqProxy: requests.RequestAuth.Proxy = Proxy("username", "password")

@ val res = requests.get("http://localhost:8881", auth=reqProxy)
requests.TimeoutException: Request to http://localhost:8881 timed out. (readTimeout: 10000, connectTimout: 10000)
...<snip, irrelevant>
```

2) Locally-received values using `nc`:
```sh
 learn-scala-hands-on ツ nc -l 8881
GET / HTTP/1.1
User-Agent: requests-scala
Accept-Encoding: gzip, deflate
Accept: */*
Authorization: Proxy-Authorization dXNlcm5hbWU6cGFzc3dvcmQ=  # <-- note this
Cache-Control: no-cache
Pragma: no-cache
Host: localhost:8881
Connection: keep-alive
```

`Proxy-Authorization` is a standalone header [0], and should not be passed in `Authorization`.

This PR fixes it by replacing `RequestAuth.header` with a `RequestAuth.credentials` that returns the built credential to be passed as a header value into the connection. In the Requester, it performs a match on `RequestAuth.{TYPE}` to determine the header key/value to set.

Unfortunately, I'm unable to get unit tests for proxy auth working - most services similar to httpbin (including it) doesn't echo the `Proxy-Authorization` value back, according to specs [1] [2]. We can spin up a local http server within the test environment to echo stuff back, though (it'd also reduce CI runtime if it no longer relies on external network requests). I'll leave that to you folks; for now I've commented out the test case and left some notes in there - if you switch to a locally-managed test env, uncommenting and pointing the request to the internal service should make the test pass :)

I manually tested the proxy auth portion against localhost:
```
(fix-proxy-auth ±) requests-scala ✖ nc -l 8881
GET / HTTP/1.1
User-Agent: requests-scala
Accept-Encoding: gzip, deflate
Accept: */*
Proxy-Authorization: Basic Zm9vOmJhcg==
Cache-Control: no-cache
Pragma: no-cache
Host: localhost:8881
Connection: keep-alive
```

[0] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization
[1] https://tools.ietf.org/html/rfc7235#section-4.4
[2] postmanlabs/httpbin#465

(p/s: I'm very new to Scala, would really love any and all feedback - thank you!)