### PR TITLE
fix compression and tests therefore

### DIFF
--- a/requests/test/src-2/requests/Scala2RequestTests.scala
+++ b/requests/test/src-2/requests/Scala2RequestTests.scala
@@ -14,31 +14,33 @@ object Scala2RequestTests extends TestSuite{
             "https://httpbin.org/post",
             data = Map("hello" -> "world", "foo" -> "baz"),
             chunkedUpload = chunkedUpload
-          ).text()
+          ).text
           assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
         }
       }
+
       test("put") {
         for (chunkedUpload <- Seq(true, false)) {
           val res1 = requests.put(
             "https://httpbin.org/put",
             data = Map("hello" -> "world", "foo" -> "baz"),
             chunkedUpload = chunkedUpload
-          ).text()
+          ).text
           assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
         }
       }
-      test("send"){
-        requests.send("get")("https://httpbin.org/get?hello=world&foo=baz")
 
-        val res1 = requests.send("put")(
-          "https://httpbin.org/put",
-          data = Map("hello" -> "world", "foo" -> "baz"),
-          chunkedUpload = true
-        ).text
+    test("send"){
+            requests.send("get")("https://httpbin.org/get?hello=world&foo=baz")
 
-        assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
-      }
+            val res1 = requests.send("put")(
+              "https://httpbin.org/put",
+              data = Map("hello" -> "world", "foo" -> "baz"),
+              chunkedUpload = true
+            ).text
+
+            assert(read(res1).obj("form") == Obj("foo" -> "baz", "hello" -> "world"))
+          }
     }
   }
 }

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -1,10 +1,21 @@
 package requests
 
+import java.net.InetSocketAddress
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import java.io._
+import java.util.zip._
+import scala.collection.mutable.StringBuilder
 import utest._
 import ujson._
+import requests.Compress
+import requests.Compress._
+import scala.annotation.tailrec
 
 object RequestTests extends TestSuite{
-  val tests = Tests{
+   val tests = Tests{
     test("matchingMethodWorks"){
       val requesters = Seq(
         requests.delete,
@@ -29,7 +40,8 @@ object RequestTests extends TestSuite{
           }
         }
       }
-    }
+     }
+
     test("params"){
       test("get"){
         // All in URL
@@ -58,6 +70,7 @@ object RequestTests extends TestSuite{
         assert(read(res4).obj("args") == Obj("++-- lol" -> " !@#$%", "hello" -> "world"))
       }
     }
+
     test("multipart"){
       for(chunkedUpload <- Seq(true, false)) {
         val response = requests.post(
@@ -73,6 +86,7 @@ object RequestTests extends TestSuite{
         assert(read(response).obj("form") == Obj("file2" -> "Goodbye!"))
       }
     }
+
     test("cookies"){
 
       test("session"){
@@ -99,35 +113,38 @@ object RequestTests extends TestSuite{
         assert(read(res2) == Obj("cookies" -> Obj("freeform" -> "test test", "hello" -> "hello, world")))
       }
     }
-    // Tests fail with 'Request to https://httpbin.org/absolute-redirect/4 failed with status code 404'
-    // test("redirects"){
-      // test("max"){
-      //   val res1 = requests.get("https://httpbin.org/absolute-redirect/4")
-      //   assert(res1.statusCode == 200)
-      //   val res2 = requests.get("https://httpbin.org/absolute-redirect/5")
-      //   assert(res2.statusCode == 200)
-      //   val res3 = requests.get("https://httpbin.org/absolute-redirect/6", check = false)
-      //   assert(res3.statusCode == 302)
-      //   val res4 = requests.get("https://httpbin.org/absolute-redirect/6", maxRedirects = 10)
-      //   assert(res4.statusCode == 200)
-      // }
-      // test("maxRelative"){
-      //   val res1 = requests.get("https://httpbin.org/relative-redirect/4")
-      //   assert(res1.statusCode == 200)
-      //   val res2 = requests.get("https://httpbin.org/relative-redirect/5")
-      //   assert(res2.statusCode == 200)
-      //   val res3 = requests.get("https://httpbin.org/relative-redirect/6", check = false)
-      //   assert(res3.statusCode == 302)
-      //   val res4 = requests.get("https://httpbin.org/relative-redirect/6", maxRedirects = 10)
-      //   assert(res4.statusCode == 200)
-      // }
-    // }
+
+    //Tests fail with 'Request to https://httpbin.org/absolute-redirect/4 failed with status code 404'
+    test("redirects"){
+      test("max"){
+        val res1 = requests.get("https://httpbin.org/absolute-redirect/4")
+        assert(res1.statusCode == 200)
+        val res2 = requests.get("https://httpbin.org/absolute-redirect/5")
+        assert(res2.statusCode == 200)
+        val res3 = requests.get("https://httpbin.org/absolute-redirect/6", check = false)
+        assert(res3.statusCode == 302)
+        val res4 = requests.get("https://httpbin.org/absolute-redirect/6", maxRedirects = 10)
+        assert(res4.statusCode == 200)
+      }
+      test("maxRelative"){
+        val res1 = requests.get("https://httpbin.org/relative-redirect/4")
+        assert(res1.statusCode == 200)
+        val res2 = requests.get("https://httpbin.org/relative-redirect/5")
+        assert(res2.statusCode == 200)
+        val res3 = requests.get("https://httpbin.org/relative-redirect/6", check = false)
+        assert(res3.statusCode == 302)
+        val res4 = requests.get("https://httpbin.org/relative-redirect/6", maxRedirects = 10)
+        assert(res4.statusCode == 200)
+      }
+    }
+
     test("streaming"){
       val res1 = requests.get("http://httpbin.org/stream/5").text()
       assert(res1.linesIterator.length == 5)
       val res2 = requests.get("http://httpbin.org/stream/52").text()
       assert(res2.linesIterator.length == 52)
     }
+
     test("timeouts"){
       test("read"){
         intercept[TimeoutException] {
@@ -144,6 +161,7 @@ object RequestTests extends TestSuite{
         }
       }
     }
+
     test("failures"){
       intercept[UnknownHostException]{
         requests.get("https://doesnt-exist-at-all.com/")
@@ -156,6 +174,7 @@ object RequestTests extends TestSuite{
         requests.get("://doesnt-exist.com/")
       }
     }
+
     test("decompress"){
       val res1 = requests.get("https://httpbin.org/gzip")
       assert(read(res1.text()).obj("headers").obj("Host").str == "httpbin.org")
@@ -171,29 +190,33 @@ object RequestTests extends TestSuite{
 
       (res1.bytes.length, res2.bytes.length, res3.bytes.length, res4.bytes.length)
     }
-    test("compression"){
-      val res1 = requests.post(
-        "https://httpbin.org/post",
-        compress = requests.Compress.None,
-        data = new RequestBlob.ByteSourceRequestBlob("Hello World")
-      )
-      assert(res1.text().contains(""""Hello World""""))
 
-      val res2 = requests.post(
-        "https://httpbin.org/post",
-        compress = requests.Compress.Gzip,
-        data = new RequestBlob.ByteSourceRequestBlob("I am cow")
-      )
-      assert(res2.text().contains("data:application/octet-stream;base64,H4sIAAAAAAAAAA=="))
+     test("compression"){
+          val res1 = requests.post(
+            "https://httpbin.org/post",
+            compress = requests.Compress.None,
+            data = new RequestBlob.ByteSourceRequestBlob("Hello World")
+          )
+          assert(res1.text.contains(""""Hello World""""))
 
-      val res3 = requests.post(
-        "https://httpbin.org/post",
-        compress = requests.Compress.Deflate,
-        data = new RequestBlob.ByteSourceRequestBlob("Hear me moo")
-      )
-      assert(res3.text().contains("data:application/octet-stream;base64,eJw="))
-      res3.text()
-    }
+          val res2 = requests.post(
+            "https://httpbin.org/post",
+            compress = requests.Compress.Gzip,
+            data = new RequestBlob.ByteSourceRequestBlob("I am cow")
+          )
+          assert(read(new String(res2.bytes))("data").toString ==
+             """"data:application/octet-stream;base64,H4sIAAAAAAAAAPNUSMxVSM4vBwCAGeD4CAAAAA=="""")
+
+          val res3 = requests.post(
+            "https://httpbin.org/post",
+            compress = requests.Compress.Deflate,
+            data = new RequestBlob.ByteSourceRequestBlob("Hear me moo")
+          )
+          assert(read(new String(res2.bytes))("data").toString == 
+            """"data:application/octet-stream;base64,H4sIAAAAAAAAAPNUSMxVSM4vBwCAGeD4CAAAAA=="""")
+
+     }
+
     test("headers"){
       test("default"){
         val res = requests.get("https://httpbin.org/headers").text()
@@ -207,6 +230,7 @@ object RequestTests extends TestSuite{
         }
       }
     }
+
     test("clientCertificate"){
       val base = "./requests/test/resources"
       val url = "https://client.badssl.com"
@@ -253,6 +277,7 @@ object RequestTests extends TestSuite{
         assert(res.statusCode == 400)
       }
     }
+
     test("selfSignedCertificate"){
       val res = requests.get(
         "https://self-signed.badssl.com",
@@ -260,6 +285,7 @@ object RequestTests extends TestSuite{
       )
       assert(res.statusCode == 200)
     }
+
     test("gzipError"){
       val response = requests.head("https://api.github.com/users/lihaoyi")
       assert(response.statusCode == 200)
@@ -268,5 +294,86 @@ object RequestTests extends TestSuite{
       assert(response.headers.keySet.map(_.toLowerCase).contains("content-length"))
       assert(response.headers.keySet.map(_.toLowerCase).contains("content-type"))
     }
+
+    /**
+      * Compress with each compression mode and call server. Server expands
+      * and passes it back so we can compare
+      */
+  test("compressionData") {
+    import Compress._
+    val str = "I am deflater mouse"
+    Seq(None, Gzip, Deflate).foreach(c => 
+       Server.use {
+          assert(str == requests.post(
+                "http://localhost:58080/test",
+                compress = c,
+                data = str
+              ).data.toString)
+       })
+     }
+  }
+}
+
+/** A server we start for above test or two. Assumes port 58080 is available */
+class Server extends HttpHandler {
+  val server: HttpServer = HttpServer.create(new InetSocketAddress(58080), 0)
+  server.createContext("/test", this)
+  server.setExecutor(null); // default executor
+  server.start();
+
+  def stop(): Unit = server.stop(0)
+
+  override def handle(t: HttpExchange) {
+      val h: java.util.List[String] = t.getRequestHeaders.get("Content-encoding")
+      val c: Compress = if (h == null) None
+         else if (h.contains("gzip")) Gzip
+         else if (h.contains("deflate")) Deflate
+         else None
+      val msg = new Plumper(c).decompress(t.getRequestBody)
+      t.sendResponseHeaders(200, msg.length)
+      t.getResponseBody.write(msg.getBytes())
+    }
+}
+
+object Server {
+   def use(doIt : => Unit) : Unit = {
+      val server = new Server
+      try doIt
+      finally server.stop()
+   }
+}
+
+/**
+  * Stream uncompresser
+  * @param c Compression mode
+  */
+class Plumper(c: Compress) {
+
+  private def wrap(is: InputStream) : InputStream = 
+      c match {
+        case None => is
+        case Gzip => new GZIPInputStream(is)
+        case Deflate => new InflaterInputStream(is)
+      }  
+
+  def decompress(compressed: InputStream): String = {
+    val gis = wrap(compressed)
+    val br = new BufferedReader(new InputStreamReader(gis, "UTF-8"))
+    val sb = new StringBuilder()
+
+    @tailrec
+    def read(): Unit = {
+          val line = br.readLine
+          if (line != null) {
+            sb.append(line)
+            read
+          }
+        }
+
+    read()
+    br.close()
+    gis.close()
+    compressed.close()
+    sb.toString()
   }
 }


### PR DESCRIPTION
I changed the code to close some output streams so the server can actually get all the data. I added some tests using a local server so it could catch the compressed data, decompress it and send it back to be checked against the original.

Also the code was allowing the verb to be passed in as any case and then checking it by uppercasing and comparing whenever it was used. Except that somebody forgot to upper case it in one place which seemed like a bug. I changed the code to upper case it in one spot.

There were 4 small blocks of code that were trivially reduced to 1 and who could resist? 

There were some existing compression tests that were failing once the change was made. The test was to make sure the response data had a specific value. One got the impression that someone just wrote the test after seeing the returned value, but who knows? I changed the tests to match the new returned values.

I uncommented some tests and they didn't blow up, so I left them. Maybe I went rogue ...

I don't think there is anything else of substance.