### PR TITLE
refactor(ci): change the way releases are automated

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -73,11 +73,7 @@ jobs:
           fi
       - name: Create GitHub Release
         id: create_gh_release
-        uses: actions/create-release@v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body:
-          draft: false
+          generate_release_notes: true
+          append_body: https://github.com/com-lihaoyi/requests-scala#changelog


### PR DESCRIPTION
A lot of users will get Steward PRs that automatically link to the
release page of that release. For example with the last release here
this linked to
https://github.com/com-lihaoyi/requests-scala/releases/tag/0.8.0. The
thing is, this page is empty and doesn't tell the user anything. I know
it's common in the com-lihaoyi ecosystem to include the changelog in the
readme, so maybe we can also automate the release better. This pr
changes a couple things:

- Changes the actual github action in control of the release. The one we
  were using before (https://github.com/actions/create-release) is
  archived and no longer maintained. This switches to a new one that
  from what I can tell is the most popular
  (https://github.com/softprops/action-gh-release).
- Use the `generate_release_notes` option which will automate generating
  the release notes by just putting all the commits for this release in
  there.
- Use `append_body` to also then link to the changelog in the readme.

This should be a nicer experience for those clicking the link with
Steward without changing the way you currently manually do your
changelog.
