### PR TITLE
Fix[bug] -> Session cookies without Double quotes

### DIFF
--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -245,7 +245,7 @@ case class Requester(verb: String,
           connection.setRequestProperty(
             "Cookie",
             allCookies
-              .map{case (k, v) => s"""$k="$v""""}
+              .map{case (k, v) => s"$k=$v"}
               .mkString("; ")
           )
         }      


### PR DESCRIPTION
The session cookie values exhibit an additional presence of double quotes within the value, as clearly demonstrated in the attached screenshot depicting the tracked Scala request in Burp Suite.
![scala_request_lib](https://github.com/com-lihaoyi/requests-scala/assets/80740535/0eff32cf-f1a5-4684-a6e0-83cd37abb294)
As a consequence, the requested server is unable to retrieve the information associated with the cookies sent in the requested payload.
The updated pull request has modified the source code of the Scala request to include the cookie values without double quotes. The tracked HTTP request in the Burp Suite, depicted in the screenshot below, was sent by the modified Scala request library.
![modifies_scala_request_lib](https://github.com/com-lihaoyi/requests-scala/assets/80740535/98977c9a-1c2c-442d-bb6b-2c01aaf85347)
