### PR TITLE
[doc] add the empty parameter for text in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ r.statusCode
 r.headers("content-type")
 // Buffer("application/json; charset=utf-8")
 
-r.text
+r.text()
 // {"login":"lihaoyi","id":934140,"node_id":"MDQ6VXNlcjkzNDE0MA==",...
 ```
 
@@ -154,11 +154,11 @@ r.headers("content-type")
 
 As seen earlier, you can use `.statusCode` and `.headers` to see the relevant
 metadata of your HTTP response. The response data is in the `.data` field of the
-`Response` object. Most often, it's text, which you can decode using the `.text`
+`Response` object. Most often, it's text, which you can decode using the `.text()`
 property as shown below:
 
 ```scala
-r.text
+r.text()
 // [{"id":"7990061484","type":"PushEvent","actor":{"id":6242317,"login":...
 ```
 
@@ -244,7 +244,7 @@ the server:
 ```scala
 val r = requests.get("https://api.github.com/events")
 
-val json = ujson.read(r.text)
+val json = ujson.read(r.text())
 
 json.arr.length
 // 30
@@ -387,7 +387,7 @@ r.cookies
 
 val r2 = requests.get("https://httpbin.org/cookies", cookies = r.cookies)
 
-r2.text
+r2.text()
 // {"cookies":{"freeform":"test"}}
 ```
 
@@ -500,7 +500,7 @@ val r = s.get("https://httpbin.org/cookies/set?freeform=test")
 
 val r2 = s.get("https://httpbin.org/cookies")
 
-r2.text
+r2.text()
 // {"cookies":{"freeform":"test"}}
 ```
 
@@ -519,12 +519,12 @@ val s = requests.Session(
 
 val r1 = s.get("https://httpbin.org/cookies")
 
-r1.text
+r1.text()
 // {"cookies":{"cookie":"vanilla"}}
 
 val r2 = s.get("https://httpbin.org/headers")
 
-r2.text
+r2.text()
 // {"headers":{"X-Special-Header":"omg", ...}}
 ```
 
@@ -558,7 +558,7 @@ val r = requests.get(
   params = Map("q" -> "http language:scala", "sort" -> "stars")
 )
 
-r.text
+r.text()
 // {"login":"lihaoyi","id":934140,"node_id":"MDQ6VXNlcjkzNDE0MA==",...
 ```
 ```scala


### PR DESCRIPTION
Following the https://github.com/com-lihaoyi/requests-scala/pull/66 , the PR is to add the empty parameter list to calls to geny's text() method.

Because when I try to run with scala-3.4.1 with `r.text` , it fails with
```
[info] compiling 1 Scala source to /tmp/s/target/scala-3.4.1/classes ...
[error] -- [E100] Syntax Error: /tmp/s/src/main/scala/Main.scala:7:5 -------------------
[error] 7 |  r2.text
[error]   |  ^^^^^^^
[error]   |  method text in trait ByteData must be called with () argument
[error]   |
[error]   | longer explanation available when compiling with `-explain`
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 5 s, completed May 16, 2024, 12:35:38 PM
```