### PR TITLE
Fix handling of HTTP 304

### DIFF
--- a/requests/src/requests/Requester.scala
+++ b/requests/src/requests/Requester.scala
@@ -291,7 +291,9 @@ case class Requester(verb: String,
           }
         }
 
-        if (responseCode.toString.startsWith("3") && maxRedirects > 0){
+        if (responseCode.toString.startsWith("3") &&
+            responseCode.toString != "304" &&
+            maxRedirects > 0){
           val out = new ByteArrayOutputStream()
           Util.transferTo(connection.getInputStream, out)
           val bytes = out.toByteArray
@@ -344,7 +346,7 @@ case class Requester(verb: String,
             }
           }
 
-          if (streamHeaders.is2xx || !check) processWrappedStream(f)
+          if (streamHeaders.statusCode == 304 || streamHeaders.is2xx || !check) processWrappedStream(f)
           else {
             val errorOutput = new ByteArrayOutputStream()
             processWrappedStream(geny.Internal.transfer(_, errorOutput))

--- a/requests/test/src/requests/RequestTests.scala
+++ b/requests/test/src/requests/RequestTests.scala
@@ -125,6 +125,10 @@ object RequestTests extends TestSuite{
       }
     }
 
+    test("test_reproduction"){
+      requests.get("http://httpbin.org/status/304").text()
+
+    }
     test("streaming"){
       val res1 = requests.get("http://httpbin.org/stream/5").text()
       assert(res1.linesIterator.length == 5)


### PR DESCRIPTION
https://github.com/com-lihaoyi/requests-scala/issues/105

304 is not a redirect, so it does not have a `location` header like other 3xx return codes, and is not a failure

Added a unit test to confirm the fix